### PR TITLE
Corrections format fichier d2i

### DIFF
--- a/pages/Format-Fichiers-d2i.md
+++ b/pages/Format-Fichiers-d2i.md
@@ -1,41 +1,41 @@
 # Format de fichier d2i
 
-Le format de fichier d2i est un format créer par Ankama pour qui à pour but de stocker des chaines de caractères (nom des items, dialogues des pnjs, etc...) correspondant à des clés, ce sont les fichiers "langues" du client.
+Le format de fichier d2i est un format crÃ©Ã© par Ankama qui a pour but de stocker des chaines de caractÃ¨res (nom des items, dialogues des pnjs, ...) correspondant Ã  des clÃ©s, ce sont les fichiers "lang" du client.
 
-### La structure d’un fichier d2i :
-* L'indexe des indexes (int)
-* Les données (chaines de caractères précédé de leur longueur)
+### La structure dâ€™un fichier d2i
+* L'index des indexes (int)
+* Les donnÃ©es (chaÃ®nes de caractÃ¨res UTF-8 prÃ©cÃ©dÃ©es de leur longueur)
+* La taille en octets de la table des indexes (int)  
 * La table des indexes
-    * Le nombre d'indexes (int)  
-    * [--Répétition des 4 prochains points jusqu'a la fin du fichier--]
-    * La clé (int)
+    * [--RÃ©pÃ©tition des 4 prochains points jusqu'Ã  la fin du fichier--]
+    * La clÃ© (int)
     * Indicateur diacritique (bool)
     * Le pointeur (int)
-    * Le pointeur diacritique (int) (non représenté sur le schema)
+    * Le pointeur diacritique (int) (non reprÃ©sentÃ© sur le schÃ©ma)
 
-note : dans la représentation ci-dessous il est considéré qu'aucunes des données ne comporte de chaines diacritiques
+note : dans la reprÃ©sentation ci-dessous il est considÃ©rÃ© qu'aucune des donnÃ©es ne comporte de chaine diacritique
 ![structure](../resources/format-fichiers/d2i/d2i-structure.png)
 
-### L'indexe des indexes :
+### L'index des indexes
 
-Correspond à l'offset de la table des indexes
+Correspond Ã  l'offset de la table des indexes.
 
-### Les données :
+### Les donnÃ©es
 
-Un short contenant la longueur de la chaine puis la chaine de caractères
+Les donnÃ©es sont des chaÃ®nes de caractÃ¨res au format UTF-8. Chaque chaÃ®ne est prÃ©cÃ©dÃ©e de sa longueur sur deux octets (short).
 
-### La table des indexes :
+### La table des indexes
 
-Le nombre d'indexes puis les indexes
+La taille (en octets) de la table des indexes puis les indexes.
 
-### Les indexes :
+### Les indexes
 
-Les indexes sont composé de 3 à 4 elements :
+Les indexes sont composÃ©s de 3 ou 4 Ã©lÃ©ments :
 
-1. La clé : Appelé par exemple dans les fichiers d2o, c'est le "numéro d'identification" de la donnée
-2. Indicateur diacritique : Indique si il existe une donnée diacritique pour cette clé
-3. Pointeur : Emplacement de la chaine
-4. Pointeur diacritique : Emplacement de la chaine diacritique si existante
+1. La clÃ© : AppelÃ©e par exemple dans les fichiers d2o, c'est l'identifiant de la donnÃ©e.
+2. Indicateur diacritique : Indique s'il existe une donnÃ©e diacritique pour cette clÃ©.
+3. Pointeur : Emplacement de la chaine dans le fichier.
+4. Pointeur diacritique : Emplacement de la chaine diacritique dans le fichier, si l'indicateur diacritique est Ã  true.
 
-# Informations suplémentaires
-- [Définition du terme : diacritique](https://fr.wikipedia.org/wiki/Diacritique)
+# Informations supplÃ©mentaires
+- [DÃ©finition du terme : diacritique](https://fr.wikipedia.org/wiki/Diacritique)


### PR DESCRIPTION
Corrections grammaticales, orthographiques, syntaxiques.
Correction d'une erreur : la table des indexes est précédée de sa taille en octets et non pas du nombre d'indexes.